### PR TITLE
fix: waiting queue logic may cause deadlock, test logic may cause panic

### DIFF
--- a/rego.go
+++ b/rego.go
@@ -91,6 +91,7 @@ Loop:
 			case r.workerChan <- r.waiting.Front().Value.(func()):
 				r.waiting.Remove(r.waiting.Front())
 			}
+			continue
 		}
 
 		select {

--- a/rego_test.go
+++ b/rego_test.go
@@ -27,8 +27,8 @@ func TestRego(t *testing.T) {
 			respChan <- v
 		})
 	}
-	close(respChan)
 	r.Stop()
+	close(respChan)
 
 	respSet := map[string]bool{}
 	for v := range respChan {


### PR DESCRIPTION
1. waiting queue logic may cause multiple idle timeouts, then causing deadlock when kill idle worker.
2. in function TestRego, should stop Rego first then close channel, or may occur panic by send to closed channel.